### PR TITLE
set the default format to text

### DIFF
--- a/modules/benchmetrics/files/tpc/tpcds/settings/etlsettings.sql
+++ b/modules/benchmetrics/files/tpc/tpcds/settings/etlsettings.sql
@@ -9,3 +9,5 @@ set hive.exec.parallel=true;
 set hive.exec.reducers.max=2000;
 set hive.stats.autogather=true;
 set hive.optimize.sort.dynamic.partition=true;
+set hive.default.fileformat=TextFile;
+set hive.default.fileformat.managed=TextFile;


### PR DESCRIPTION
in case the env does not set the default table format to text. @cartershanklin  can you review.
